### PR TITLE
Add option for renaming files

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,5 +71,7 @@ This project is opened to everyone to contribute. If you want to, please read ou
 
 **Please don't forget to run `npm run demo` before submitting any change just to double check that everything is working like a charm.** We are expecting to have this as part of the testing suite but we are still working on it.
 
+Please use `npm run commit` instead of `git commit -m "your message"` since we're using semantic release + commitizen and we aim to have things as tidy as possible.
+
 ## Issues / bugs
 We are working once on a while in this small library. Please report an issue [here](https://github.com/andresdavid90/pizza-guy/issues) and we'll take a look as soon as we can.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 If you already have a big list of urls of files that you want to download but you don't know how, this is your module.
 
-The idea is to support really big lists of files that would be insane to download simultaneusly since Node would break for this kind of cases. Hope others to support this cause. ✌🏻
+The idea is to support really big lists of files that would be insane to download simultaneously since Node would break for this kind of cases. Hope others to support this cause. ✌🏻
 
 ## How to use
 
@@ -31,10 +31,20 @@ const images = [
   'https://some.domain.com/file2.png'
 ];
 ```
+or, if you want to alter the filenames on download...
+
+```
+const image = [
+  { url: 'http://some.domain.com/file0.jpg', name: 'goat.jpg' },
+  { url: 'http://some.domain.com/file1.gif', name: 'cat.gif' },
+  { url: 'https://some.domain.com/file2.png', name: 'hawk.png' }
+];
+```
+
 ### Execute
 ```
 pizzaGuy
-  // Pass an array of strings containing urls...
+  // Pass an array of strings containing urls or an array of objects with urls and names...
   .deliver(images)
   // Absolute or relative path to save these files...
   .onAddress('./some-path')

--- a/demo/index.js
+++ b/demo/index.js
@@ -4,10 +4,10 @@ const images = [
   'http://www.italianpizzas.co.uk/assets/images/italianpizza.jpg',
   'http://www.mrwallpaper.com/wallpapers/delicious-italian-pizza.jpg',
   'http://previews.123rf.com/images/foodandmore/foodandmore1209/foodandmore120900019/15145674-Delicious-freshly-cooked-homemade-vegetarian-Italian-pizza-topped-with-cheese-vegetables-and-fresh-h-Stock-Photo.jpg',
-  'http://previews.123rf.com/images/foodandmore/foodandmore1304/foodandmore130400224/19271412-Italian-pizza-with-tomato-topped-with-melted-golden-cheese-herbs-and-basil-served-on-a-round-wooden--Stock-Photo.jpg',
-  'http://www.godine.co.uk/blog/wp-content/uploads/2009/12/Italian-pizza1.jpg',
-  'http://www.chamonix.com/img/sitra/fiche/39493-1-pizza-valerio.jpg',
-  'http://previews.123rf.com/images/jagcz/jagcz1211/jagcz121100303/16598280-Delicious-italian-pizza-served-on-wooden-table-Stock-Photo-pizza-food-vegetarian.jpg'
+  { url: 'http://previews.123rf.com/images/foodandmore/foodandmore1304/foodandmore130400224/19271412-Italian-pizza-with-tomato-topped-with-melted-golden-cheese-herbs-and-basil-served-on-a-round-wooden--Stock-Photo.jpg', name: 'pizza-italian-1.jpg' },
+  { url: 'http://www.godine.co.uk/blog/wp-content/uploads/2009/12/Italian-pizza1.jpg', name: 'pizza-italian-2.jpg' },
+  { url: 'http://www.chamonix.com/img/sitra/fiche/39493-1-pizza-valerio.jpg', name: 'pizza-valerio.jpg' },
+  { url: 'http://previews.123rf.com/images/jagcz/jagcz1211/jagcz121100303/16598280-Delicious-italian-pizza-served-on-wooden-table-Stock-Photo-pizza-food-vegetarian.jpg', name: 'pizza-vegetarian.jpg' }
 ];
 
 pizzaGuy

--- a/package.json
+++ b/package.json
@@ -48,14 +48,30 @@
     "mocha": "2.4.5",
     "nyc": "7.0.0",
     "semantic-release": "^4.3.5",
-    "sinon": "1.17.4"
+    "sinon": "1.17.4",
+    "validate-commit-msg": "2.6.1"
   },
   "config": {
     "commitizen": {
       "path": "node_modules/cz-conventional-changelog"
     },
     "ghooks": {
-      "pre-commit": "npm run test && npm run lint"
+      "pre-commit": "npm run test && npm run lint",
+      "commit-msg": "validate-commit-msg"
+    },
+    "validate-commit-msg": {
+      "helpMessage": "\nLooks like you're not using the `npm run commit` command. Please use it instead of `git commit`.\n",
+      "types": [
+        "feat",
+        "fix",
+        "docs",
+        "style",
+        "refactor",
+        "perf",
+        "test",
+        "chore"
+      ],
+      "warnOnFail": false
     }
   },
   "dependencies": {

--- a/src/data-adapter.js
+++ b/src/data-adapter.js
@@ -14,9 +14,20 @@ const parseDirPath = (dirPath) => {
 const removeDuplicates = arr => Array.from(new Set(arr));
 
 export default function getDataAdapterOptions(data, savePath = process.cwd()) {
-  return removeDuplicates(data).map((urlString) => ({
-    host: url.parse(urlString).host,
-    path: url.parse(urlString).path,
-    fileName: `${parseDirPath(savePath)}${path.basename(urlString)}`
-  }));
+  return removeDuplicates(data).map((item) => {
+    const itemurl = (typeof item === 'string') ? item : item.url;
+    let name = '';
+    if (typeof item === 'string') {
+      name = path.basename(item);
+    } else if (!item.name) {
+      name = path.basename(item.url);
+    } else {
+      name = item.name;
+    }
+    return {
+      host: url.parse(itemurl).host,
+      path: url.parse(itemurl).path,
+      fileName: `${parseDirPath(savePath)}${name}`
+    };
+  });
 }

--- a/src/pizza-guy.js
+++ b/src/pizza-guy.js
@@ -13,7 +13,7 @@ module.exports = {
       throw Error('The list must be an array');
     }
     if (!list.every(
-        (item) => typeof item === 'string' || (typeof item === 'object' && item.url)
+        (item) => typeof item === 'string' || item.hasOwnProperty('url')
         )) {
       throw Error('The list must contains just strings or be objects wiht the url property.');
     }

--- a/src/pizza-guy.js
+++ b/src/pizza-guy.js
@@ -12,8 +12,10 @@ module.exports = {
     if (!Array.isArray(list)) {
       throw Error('The list must be an array');
     }
-    if (!list.every((item) => typeof item === 'string')) {
-      throw Error('The list must contains just strings');
+    if (!list.every(
+        (item) => typeof item === 'string' || (typeof item === 'object' && item.url)
+        )) {
+      throw Error('The list must contains just strings or be objects wiht the url property.');
     }
     filesList = list;
 

--- a/test/data-adapter.spec.js
+++ b/test/data-adapter.spec.js
@@ -5,38 +5,83 @@ describe('data-adapter', () => {
   it('should create an array of objects when passing an array of relative paths', () => {
     expect(
       dataAdapter(
-        ['http://some.domain.com/image1.jpg'],
+        [
+          'http://some.domain.com/image1.jpg',
+          { url: 'http://someother.domain.com/image2.jpg', name: 'image2_renamed.jpg' }
+        ],
         'myfolder'
       )
     ).toEqual([{
       host: 'some.domain.com',
       path: '/image1.jpg',
       fileName: `${process.cwd()}/myfolder/image1.jpg`
+    },
+    {
+      host: 'someother.domain.com',
+      path: '/image2.jpg',
+      fileName: `${process.cwd()}/myfolder/image2_renamed.jpg`
     }]);
   });
 
   it('should create an array of objects when passing an array of absolute paths', () => {
     expect(
       dataAdapter(
-        ['http://some.domain.com/image1.jpg'],
+        [
+          'http://some.domain.com/image1.jpg',
+          { url: 'http://someother.domain.com/image2.jpg', name: 'image2_renamed.jpg' }
+        ],
         '/myfolder'
       )
     ).toEqual([{
       host: 'some.domain.com',
       path: '/image1.jpg',
       fileName: '/myfolder/image1.jpg'
+    },
+    {
+      host: 'someother.domain.com',
+      path: '/image2.jpg',
+      fileName: '/myfolder/image2_renamed.jpg'
     }]);
   });
 
   it('should create an array of objects without providing the savePath parameter', () => {
     expect(
       dataAdapter(
-        ['http://some.domain.com/image1.jpg']
+        [
+          'http://some.domain.com/image1.jpg',
+          { url: 'http://someother.domain.com/image2.jpg', name: 'image2_renamed.jpg' }
+        ]
       )
     ).toEqual([{
       host: 'some.domain.com',
       path: '/image1.jpg',
       fileName: `${process.cwd()}/image1.jpg`
+    },
+    {
+      host: 'someother.domain.com',
+      path: '/image2.jpg',
+      fileName: `${process.cwd()}/image2_renamed.jpg`
+    }]);
+  });
+
+  it('should use original image name if name property is unset or empty', () => {
+    expect(
+      dataAdapter(
+        [
+           { url: 'http://some.domain.com/image1.jpg', name: '' },
+          { url: 'http://someother.domain.com/image2.jpg' }
+        ],
+        'myfolder'
+      )
+    ).toEqual([{
+      host: 'some.domain.com',
+      path: '/image1.jpg',
+      fileName: `${process.cwd()}/myfolder/image1.jpg`
+    },
+    {
+      host: 'someother.domain.com',
+      path: '/image2.jpg',
+      fileName: `${process.cwd()}/myfolder/image2.jpg`
     }]);
   });
 });

--- a/test/pizza-guy.spec.js
+++ b/test/pizza-guy.spec.js
@@ -8,14 +8,16 @@ describe('pizza-guy', () => {
         .toThrow(/The list must be an array/);
     });
 
-    it('should throw an error with arrays containing non-string objects', () => {
-      expect(() => pizzaGuy.deliver([{}]))
+    it('should throw an error with arrays containing non-string objects without url property',
+      () => {
+        expect(() => pizzaGuy.deliver([{}]))
         .toThrow(/The list must contains just strings/);
-    });
+      });
 
     it('should return itself when running correctly', () => {
       expect(pizzaGuy.deliver([
-        'http://andrescarreno.co/storage/cache/images/000/317/IMG-2606,huge.1459740781.jpg'
+        'http://andrescarreno.co/storage/cache/images/000/317/IMG-2606,huge.1459740781.jpg',
+        { url: 'http://andrescarreno.co/storage/cache/images/000/317/IMG-2606,huge.1459740781.jpg', name: 'andres.jpg' }
       ])).toBe(pizzaGuy);
     });
   });


### PR DESCRIPTION
Instead of just passing an array of URLs, you can pass an array of objects with a url and an (optional) name property.

If the name property is present the file will be saved with that name instead of its original one.

Hopefully I set-up the tests right, haven't used that method before. They passed when I ran my commit.

(Setting this up so I can rename the tumblr likes to something more sensical in a future pull request on tumblr-lks-downldr...)

(Also fixed a typo in the readme)