### PR TITLE
chore(eslint): Add async/await support in eslint

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,7 +1,9 @@
 {
+  "parser": "babel-eslint",
   "extends": "airbnb",
   "plugins": [
-    "react"
+    "react",
+    "babel"
   ],
   "env": {
     "node": true,
@@ -10,6 +12,7 @@
   "rules": {
     "space-before-function-paren": [2, "never"],
     "no-unused-vars": ["error", { "argsIgnorePattern": "^_", "varsIgnorePattern": "^_" }],
-    "comma-dangle": ["error", "never"]
+    "comma-dangle": ["error", "never"],
+    "babel/generator-star-spacing": 1
   }
 }

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "cz-conventional-changelog": "1.1.5",
     "eslint": "2.13.1",
     "eslint-config-airbnb": "9.0.1",
+    "eslint-plugin-babel": "3.3.0",
     "eslint-plugin-import": "1.11.1",
     "eslint-plugin-jsx-a11y": "1.5.5",
     "eslint-plugin-react": "5.2.2",


### PR DESCRIPTION
Right now we have async/await support for node using babel, but Eslint was throwing errors. This commit fix them.