### PR TITLE
fix(download-file.js): Writing files just with 200 code

### DIFF
--- a/demo/index.js
+++ b/demo/index.js
@@ -17,6 +17,6 @@ pizzaGuy
     console.log(`Downloaded: ${info.fileName}`);
   })
   .onError((info) => {
-    console.log(`Download ${info.fileName} failed`);
+    console.log(`Failed: ${info.fileName}`);
   })
   .start();

--- a/src/download-file.js
+++ b/src/download-file.js
@@ -21,9 +21,17 @@ const downloadFile = (file) => {
       if (err) { // File doesn't exists yet
         request
           .get(`http://${host}${path}`)
-          .on('error', (error) => reject(error, { fileName }))
-          .pipe(fs.createWriteStream(fileName))
-          .on('close', () => resolve({ fileName, isRepeated: false }));
+          .on('response', function(response) {
+            if (response.statusCode === 200) {
+              response.request
+                .pipe(fs.createWriteStream(fileName))
+                .on('error', (error) => reject(error, { fileName }))
+                .on('close', () => resolve({ fileName, isRepeated: false }));
+            } else {
+              reject({ fileName });
+            }
+          }
+        );
       } else { // File is already on disk
         resolve({ fileName, isRepeated: true });
       }


### PR DESCRIPTION
We were writing on disk files without checking the http status code causing empty file for cases
where the request failed.